### PR TITLE
Honour `Timeout` when getting connection

### DIFF
--- a/src/epna_pool.erl
+++ b/src/epna_pool.erl
@@ -83,7 +83,7 @@ get_connection(Name) ->
 
 -spec get_connection(episcina:name(), non_neg_integer()) -> episcina:connection().
 get_connection(Name, Timeout) ->
-    {Pid, _} = gproc:await(make_registered_name(Name)),
+    {Pid, _} = gproc:await(make_registered_name(Name), Timeout),
     try
         gen_server:call(Pid, get_connection, Timeout)
     catch

--- a/src/epna_pool.erl
+++ b/src/epna_pool.erl
@@ -83,9 +83,11 @@ get_connection(Name) ->
 
 -spec get_connection(episcina:name(), non_neg_integer()) -> episcina:connection().
 get_connection(Name, Timeout) ->
-    {Pid, _} = gproc:await(make_registered_name(Name), Timeout),
+    {Time, {Pid, _}} = timer:tc(gproc, await, [make_registered_name(Name),
+                                               Timeout]),
+    Timeout1 = Timeout - trunc(Time/1000),
     try
-        gen_server:call(Pid, get_connection, Timeout)
+        gen_server:call(Pid, get_connection, Timeout1)
     catch
         _:_ ->
             gen_server:cast(Pid, {cancel_wait, erlang:self()}),


### PR DESCRIPTION
When getting a connection from a pool that does not exist - it might not have been created yet or it might have been removed - the client risks blocking forever. This PR honours the `Timeout` value passed by passing it on to `gproc:await/2`.