### PR TITLE
Erlang 18.0+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: erlang
 otp_release:
+       - 18.0
+       - 17.5
        - R16B
        - R15B02
        - R15B01


### PR DESCRIPTION
- use a compatible record-to-type declaration
- adapt to the new time API while remaining backwards compatible.