### PR TITLE
Relax `name/0` type

### DIFF
--- a/src/episcina.erl
+++ b/src/episcina.erl
@@ -20,7 +20,7 @@
               connect_fun/0,
               close_fun/0]).
 
--type name() :: binary() | atom().
+-type name() :: any().
 -type connection() :: pid() | term().
 -type connect_fun() :: fun(() -> term()).
 -type close_fun() :: fun((term()) -> ok).


### PR DESCRIPTION
The `name/0` type is set to `binary` or `atom`,
this is different from `gproc` (which has
`any`[1]). This commit changes the type to fit
with what is used by the underlying registration
library.

[1] https://github.com/uwiger/gproc/blob/0.3.1/doc/gproc.md#key